### PR TITLE
lstcp: print usage on -h or --help

### DIFF
--- a/platform/darwin/bin/lstcp
+++ b/platform/darwin/bin/lstcp
@@ -3,6 +3,17 @@
 # lstcp
 # List processes listening on TCP ports
 
+usage="usage: $(basename $0) [port...] port"
+
+for opt in $*; do
+    case $opt in
+        -h|-help|--help)
+            echo $usage
+            exit 0
+            ;;
+    esac
+done
+
 for PORT in "$@"; do
   # call lsof with a few interesting options:
   #  • `-t`: print only port numbers, don't print errors


### PR DESCRIPTION
I knew there was a manpage, but when I tried passing `-h` and `--help` I didn't get what I expected. Figured this might be helpful. 😄 