### PR TITLE
heifize: set both dates

### DIFF
--- a/platform/darwin/bin/heifize
+++ b/platform/darwin/bin/heifize
@@ -14,5 +14,6 @@ for ARG in "$@"; do
          -o "$OUTPUT_FILE"
 
     SetFile -d "$CREATED_DATE" \
+            -m "$CREATED_DATE" \
             "$OUTPUT_FILE"
 done


### PR DESCRIPTION
The modified date was being left alone, but some software will look at the modified date instead of the created date.